### PR TITLE
InCallController: don't strip can send SMS capability on MSIM

### DIFF
--- a/src/com/android/server/telecom/InCallController.java
+++ b/src/com/android/server/telecom/InCallController.java
@@ -612,11 +612,7 @@ public final class InCallController extends CallsManagerListenerBase {
         }
         properties |= convertConnectionToCallProperties(call.getConnectionProperties());
 
-        // If this is a single-SIM device, the "default SIM" will always be the only SIM.
-        boolean isDefaultSmsAccount =
-                mCallsManager.getPhoneAccountRegistrar()
-                        .isUserSelectedSmsPhoneAccount(call.getTargetPhoneAccount());
-        if (call.isRespondViaSmsCapable() && isDefaultSmsAccount) {
+        if (call.isRespondViaSmsCapable()) {
             capabilities |= android.telecom.Call.Details.CAPABILITY_RESPOND_VIA_TEXT;
         }
 


### PR DESCRIPTION
With MSIM devices, if a default SMS subscription is required with AOSP,
so logic existed to remove that flag if a default SMS sub wasn't
selected.

We support always ask, and we also now disable always ask if the default
SMS app does not support it. We can leverage this logic here and just
pass the flag along and let it be handled in the UI layer.

This also covers the edge case of when Hangouts is selected as the defualt
(does not support always ask), and the user DID have always ask selected,
and then received an incoming call, and selects to respond with an SMS:
we are still prompted to select a new SIM to send the SMS with.

Ticket: CYNGNOS-3225

Change-Id: Id5bf9c60e18278a2acabc893398e27f3ba2d4700
Signed-off-by: Roman Birg roman@cyngn.com
